### PR TITLE
Update print-temperatures.py

### DIFF
--- a/kronoterm2mqtt/examples/print-temperatures.py
+++ b/kronoterm2mqtt/examples/print-temperatures.py
@@ -4,7 +4,7 @@ pymodbus.pymodbus_apply_logging_config("DEBUG")
 client = pymodbus.client.ModbusSerialClient("/dev/ttyUSB0",  baudrate=115200)
 try:
     client.connect()
-    rr = client.read_holding_registers(2100, 10, slave=20)
+    rr = client.read_holding_registers(2100, count=10, slave=20)
     print('KRONOTERM Temperatures:', [u'{:.1f}\N{DEGREE SIGN}C'.format((t-(t>>15<<16))/10) for t in rr.registers])
 except pymodbus.ModbusException as exc:
     print(f"Received ModbusException({exc}) from library")


### PR DESCRIPTION
or else you get:
```
Traceback (most recent call last):
  File "/home/user/kronoterm2mqtt/kronoterm2mqtt/examples/print-temperatures.py", line 7, in <module>
    rr = client.read_holding_registers(2100, 10, slave=20)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ModbusClientMixin.read_holding_registers() takes 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given
```

This was introduced by https://github.com/pymodbus-dev/pymodbus/commit/5a1ebb2e9d0823fdf6c75a09f08489188c01267e and released in pymodbus 3.8.0
This change is backwards compatible (should still work on older versions).