### PR TITLE
Add Docker support and MQTT TLS authentication

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.venv-app/
+.git/
+*.egg-info
+__pycache__
+dist/
+coverage.*
+*.log
+etera-uart-bridge/.github/
+etera-uart-bridge/pcb/
+etera-uart-bridge/images/
+etera-uart-bridge/pio-eub-firmware/
+.github/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 /dist/
 /coverage.json
 /coverage.xml
+/config/
 
 !.github
 !.editorconfig
@@ -13,3 +14,4 @@ __pycache__
 !.pre-commit-config.yaml
 !.pre-commit-hooks.yaml
 !.gitkeep
+!.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.13-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        libc6-dev \
+        nano \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy project files needed for build
+COPY uv.lock pyproject.toml cli.py README.md ./
+
+# Copy submodule for pyetera_uart_bridge
+COPY etera-uart-bridge/pyetera-uart-bridge/pyetera-uart-bridge/ \
+     etera-uart-bridge/pyetera-uart-bridge/pyetera-uart-bridge/
+
+# Copy source code and recreate the symlink that points to the submodule
+COPY kronoterm2mqtt/ kronoterm2mqtt/
+RUN rm -rf kronoterm2mqtt/pyetera_uart_bridge && \
+    ln -s ../etera-uart-bridge/pyetera-uart-bridge/pyetera-uart-bridge \
+          kronoterm2mqtt/pyetera_uart_bridge
+
+# Bootstrap: create venv and install dependencies
+RUN python3 cli.py --help
+
+ENTRYPOINT ["python3", "cli.py"]
+CMD ["publish-loop"]

--- a/README.md
+++ b/README.md
@@ -143,6 +143,74 @@ venv/bin/kronoterm2mqtt_app edit-settings
 venv/bin/kronoterm2mqtt_app print-values
 ```
 
+## Docker
+
+kronoterm2mqtt can run inside a Docker container. This is useful when you don't want to install Python dependencies on the host or when deploying on a server without direct USB access (e.g. using Modbus/TCP).
+
+### Quick start
+
+```bash
+git clone --recursive https://github.com/kosl/kronoterm2mqtt.git
+cd kronoterm2mqtt
+```
+
+Create your configuration at `config/kronoterm2mqtt.toml` (see [Setup](#setup) for details), then:
+
+```bash
+docker compose up -d
+```
+
+### Configuration
+
+The `docker-compose.yml` mounts `./config` into the container as the settings directory. Place your `kronoterm2mqtt.toml` there before starting.
+
+To edit settings interactively inside the container:
+
+```bash
+docker compose run --rm kronoterm2mqtt edit-settings
+```
+
+### Testing MQTT connection
+
+```bash
+docker compose run --rm kronoterm2mqtt test-mqtt-connection
+```
+
+### MQTT TLS
+
+To use TLS for MQTT, place your certificate files under `config/certs/` and configure `[mqtt_tls]` in your TOML settings:
+
+```toml
+[mqtt]
+host = "mqtt.example.com"
+port = 8883
+user_name = "myuser"
+password = "mypassword"
+
+[mqtt_tls]
+enabled = true
+ca_certs = "/certs/ca.crt"
+certfile = "/certs/client.crt"
+keyfile = "/certs/client.key"
+```
+
+The `docker-compose.yml` mounts `./config/certs` to `/certs` inside the container.
+
+### Serial devices (Modbus RTU)
+
+If using a USB RS485 adapter, uncomment the `devices` section in `docker-compose.yml`:
+
+```yaml
+devices:
+  - /dev/ttyUSB0:/dev/ttyUSB0
+```
+
+### Viewing logs
+
+```bash
+docker compose logs -f
+```
+
 ## Derived sensors (helpers) in Home Assistant
 
 If we are interested in some additional info derived from the heat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  kronoterm2mqtt:
+    build: .
+    container_name: kronoterm2mqtt
+    restart: unless-stopped
+    # Serial devices for Modbus communication
+    # devices:
+      # - /dev/ttyUSB0:/dev/ttyUSB0
+      # Uncomment if using the custom ETERA expander module:
+      # - /dev/ttyUSB1:/dev/ttyUSB1
+    volumes:
+      # Persist configuration across container restarts
+      - ./config:/root/.config/kronoterm2mqtt
+      # Optional: mount TLS certificates (if using MQTT TLS)
+      - ./config/certs:/certs:ro

--- a/kronoterm2mqtt/cli_app/publish-loop.py
+++ b/kronoterm2mqtt/cli_app/publish-loop.py
@@ -6,11 +6,10 @@ import time
 from cli_base.cli_tools.verbosity import setup_logging
 from cli_base.tyro_commands import TyroVerbosityArgType
 from ha_services.exceptions import InvalidStateValue
-from ha_services.mqtt4homeassistant.data_classes import MqttSettings
-from ha_services.mqtt4homeassistant.mqtt import get_connected_client
 from rich import print  # noqa
 
 from kronoterm2mqtt.cli_app import app
+from kronoterm2mqtt.mqtt_connection import get_connected_client
 from kronoterm2mqtt.mqtt_handler import KronotermMqttHandler
 from kronoterm2mqtt.user_settings import UserSettings, get_user_settings
 
@@ -26,8 +25,7 @@ def test_mqtt_connection(verbosity: TyroVerbosityArgType):
     setup_logging(verbosity=verbosity)
     user_settings: UserSettings = get_user_settings(verbosity=verbosity)
 
-    settings: MqttSettings = user_settings.mqtt
-    mqttc = get_connected_client(settings=settings, verbosity=verbosity)
+    mqttc = get_connected_client(user_settings=user_settings, verbosity=verbosity)
     mqttc.loop_start()
     mqttc.loop_stop()
     mqttc.disconnect()

--- a/kronoterm2mqtt/definitions/kronoterm_ksm.toml
+++ b/kronoterm2mqtt/definitions/kronoterm_ksm.toml
@@ -131,7 +131,7 @@ state_class = "measurement"
 unit_of_measurement = "°C"
 scale = 0.1
 
-[[sensor_disabled]]
+[[sensor]]
 register = 2160
 name = "Loop 1 thermostat temperature"
 device_class = "temperature"
@@ -149,7 +149,7 @@ scale = 0.1
 
 [[sensor]]
 register = 2191
-name = "Loop 1 current desired room temperature"
+name = "Loop 1 current desired temperature room"
 device_class = "temperature"
 state_class = "measurement"
 unit_of_measurement = "°C"

--- a/kronoterm2mqtt/definitions/kronoterm_ksm.toml
+++ b/kronoterm2mqtt/definitions/kronoterm_ksm.toml
@@ -11,6 +11,22 @@ stopbits = 1
 
 # https://developers.home-assistant.io/docs/core/entity/sensor
 
+# ============================================================
+# Statusi - system temperature correction
+# ============================================================
+
+[[sensor]]
+register = 2014
+name = "System temperature correction"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 1
+
+# ============================================================
+# Sanitarna voda (DHW)
+# ============================================================
+
 [[sensor]]
 register = 2023
 name = "Desired DHW temperature"
@@ -28,6 +44,62 @@ unit_of_measurement = "°C"
 scale = 0.1
 
 [[sensor]]
+register = 2030
+name = "DHW ECO offset"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2031
+name = "DHW comfort offset"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+# ============================================================
+# Zalogovnik (Buffer tank)
+# ============================================================
+
+[[sensor]]
+register = 2032
+name = "Desired buffer temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2034
+name = "Current desired buffer temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2040
+name = "Buffer ECO offset"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2041
+name = "Buffer comfort offset"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+# ============================================================
+# 1. krog (Loop 1)
+# ============================================================
+
+[[sensor]]
 register = 2047
 name = "Loop 1 temperature offset in ECO mode"
 device_class = "temperature"
@@ -36,28 +108,280 @@ unit_of_measurement = "°C"
 scale = 0.1
 
 [[sensor]]
-register = 2090
-name = "Operating hours compressor heating"
-device_class = "duration"
-state_class = "total_increasing"
-unit_of_measurement = "h"
-scale = 1
+register = 2048
+name = "Loop 1 temperature offset in comfort mode"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
 
 [[sensor]]
-register = 2091
-name = "Operating hours compressor heating DHW"
-device_class = "duration"
-state_class = "total_increasing"
-unit_of_measurement = "h"
-scale = 1
+register = 2128
+name = "Loop 1 current desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
 
 [[sensor]]
-register = 2095
-name = "Operating hours additional source 1"
-device_class = "duration"
-state_class = "total_increasing"
-unit_of_measurement = "h"
-scale = 1
+register = 2130
+name = "Loop 1 temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor_disabled]]
+register = 2160
+name = "Loop 1 thermostat temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2187
+name = "Loop 1 desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2191
+name = "Loop 1 current desired room temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+# ============================================================
+# 2. krog (Loop 2)
+# ============================================================
+
+[[sensor]]
+register = 2049
+name = "Loop 2 desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2051
+name = "Loop 2 current desired temperature room"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2057
+name = "Loop 2 temperature offset in ECO mode"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2058
+name = "Loop 2 temperature offset in comfort mode"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2110
+name = "Loop 2 temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2161
+name = "Loop 2 thermostat temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2188
+name = "Loop 2 current desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+# ============================================================
+# 3. krog (Loop 3)
+# ============================================================
+
+[[sensor]]
+register = 2059
+name = "Loop 3 desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2061
+name = "Loop 3 current desired temperature room"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2067
+name = "Loop 3 temperature offset in ECO mode"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2068
+name = "Loop 3 temperature offset in comfort mode"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2111
+name = "Loop 3 temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2162
+name = "Loop 3 thermostat temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2189
+name = "Loop 3 current desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+# ============================================================
+# 4. krog (Loop 4)
+# ============================================================
+
+[[sensor]]
+register = 2069
+name = "Loop 4 desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2071
+name = "Loop 4 current desired temperature room"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2077
+name = "Loop 4 temperature offset in ECO mode"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2078
+name = "Loop 4 temperature offset in comfort mode"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2112
+name = "Loop 4 temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2163
+name = "Loop 4 thermostat temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor]]
+register = 2190
+name = "Loop 4 current desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+# ============================================================
+# Bazen (Pool)
+# ============================================================
+
+[[sensor_disabled]]
+register = 2079
+name = "Pool desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor_disabled]]
+register = 2080
+name = "Pool current desired temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor_disabled]]
+register = 2086
+name = "Pool ECO offset"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor_disabled]]
+register = 2087
+name = "Pool comfort offset"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+[[sensor_disabled]]
+register = 2109
+name = "Pool temperature"
+device_class = "temperature"
+state_class = "measurement"
+unit_of_measurement = "°C"
+scale = 0.1
+
+# ============================================================
+# Ostale temperature (Other temperatures)
+# ============================================================
 
 [[sensor]]
 register = 2101
@@ -116,12 +440,108 @@ unit_of_measurement = "°C"
 scale = 0.1
 
 [[sensor_disabled]]
-register = 2109
-name = "Pool temperature"
+register = 2108
+name = "Passive cooling temperature"
 device_class = "temperature"
 state_class = "measurement"
 unit_of_measurement = "°C"
 scale = 0.1
+
+# ============================================================
+# Obratovalne ure (Operating hours)
+# ============================================================
+
+[[sensor]]
+register = 2089
+name = "Operating hours compressor cooling"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+[[sensor]]
+register = 2090
+name = "Operating hours compressor heating"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+[[sensor]]
+register = 2091
+name = "Operating hours compressor heating DHW"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+[[sensor]]
+register = 2092
+name = "Operating minutes compressor daily"
+device_class = "duration"
+state_class = "measurement"
+unit_of_measurement = "min"
+scale = 1
+
+[[sensor]]
+register = 2093
+name = "Operating hours main circulation pump"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+[[sensor]]
+register = 2094
+name = "Operating hours DHW circulation pump"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+[[sensor]]
+register = 2095
+name = "Operating hours additional source 1"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+[[sensor]]
+register = 2096
+name = "Operating hours external additional source"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+[[sensor]]
+register = 2097
+name = "Operating hours alternative source"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+[[sensor]]
+register = 2098
+name = "Operating hours heat source"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+[[sensor]]
+register = 2099
+name = "Operating hours passive cooling"
+device_class = "duration"
+state_class = "total_increasing"
+unit_of_measurement = "h"
+scale = 1
+
+# ============================================================
+# Tlaki in moč (Pressure, power, efficiency)
+# ============================================================
 
 [[sensor]]
 register = 2129
@@ -139,23 +559,6 @@ state_class = "measurement"
 unit_of_measurement = "W"
 scale = 1.0
 
-
-[[sensor]]
-register = 2130
-name = "Loop 1 temperature"
-device_class = "temperature"
-state_class = "measurement"
-unit_of_measurement = "°C"
-scale = 0.1
-
-[[sensor]]
-register = 2110
-name = "Loop 2 temperature"
-device_class = "temperature"
-state_class = "measurement"
-unit_of_measurement = "°C"
-scale = 0.1
-
 [[sensor_disabled]]
 register = 2150
 name = "Heat pump controller version"
@@ -165,29 +568,12 @@ unit_of_measurement = ""
 scale = 0.001
 
 [[sensor_disabled]]
-register = 2160
-name = "Loop 1 thermostat temperature"
-device_class = "temperature"
-state_class = "measurement"
-unit_of_measurement = "°C"
-scale = 0.1
-
-[[sensor]]
-register = 2161
-name = "Loop 2 thermostat temperature"
-device_class = "temperature"
-state_class = "measurement"
-unit_of_measurement = "°C"
-scale = 0.1
-
-[[sensor_disabled]]
 register = 2325
 name = "Setting of the pressure of the heating system"
 device_class = "pressure"
 state_class = "measurement"
 unit_of_measurement = "bar"
 scale = 0.1
-
 
 [[sensor]]
 register = 2326
@@ -221,7 +607,6 @@ state_class = "measurement"
 unit_of_measurement = "bar"
 scale = 0.1
 
-
 [[sensor_disabled]]
 register = 2371
 name = "COP"
@@ -239,6 +624,11 @@ unit_of_measurement = ""
 scale = 0.01
 
 
+# ============================================================
+# Enum senzorji (Enum sensors)
+# ============================================================
+
+# Statusi
 [[enum_sensor]]
 register = 2001
 name = "Working function"
@@ -261,26 +651,106 @@ keys = [0, 1, 2]
 values = ["cooling", "heating", "heating and cooling off"]
 
 [[enum_sensor]]
+register = 2008
+name = "Operating program"
+[[enum_sensor.options]]
+keys = [0, 1, 2, 4]
+values = ["normal", "ECO", "comfort", "screed drying"]
+
+# Sanitarna voda
+[[enum_sensor]]
+register = 2027
+name = "DHW operation status on schedule"
+[[enum_sensor.options]]
+keys = [0, 1, 2, 3]
+values = ["off", "normal", "ECO", "comfort"]
+
+# Zalogovnik
+[[enum_sensor]]
+register = 2033
+name = "Buffer regulation status"
+[[enum_sensor.options]]
+keys = [0, 1]
+values = ["constant temperature", "weather compensated"]
+
+[[enum_sensor]]
+register = 2037
+name = "Buffer operation status on schedule"
+[[enum_sensor.options]]
+keys = [0, 1, 2, 3]
+values = ["off", "normal", "ECO", "comfort"]
+
+# 1. krog
+[[enum_sensor]]
 register = 2044
 name = "Loop 1 operation status on schedule"
 [[enum_sensor.options]]
 keys = [0, 1, 2, 3]
 values = ["off", "normal", "ECO", "COM"]
 
+# 2. krog
+[[enum_sensor]]
+register = 2050
+name = "Loop 2 regulation status"
+[[enum_sensor.options]]
+keys = [0, 1]
+values = ["constant temperature", "weather compensated"]
+
+[[enum_sensor]]
+register = 2054
+name = "Loop 2 operation status on schedule"
+[[enum_sensor.options]]
+keys = [0, 1, 2, 3]
+values = ["off", "normal", "ECO", "COM"]
+
+# 3. krog
+[[enum_sensor]]
+register = 2060
+name = "Loop 3 regulation status"
+[[enum_sensor.options]]
+keys = [0, 1]
+values = ["constant temperature", "weather compensated"]
+
+[[enum_sensor]]
+register = 2064
+name = "Loop 3 operation status on schedule"
+[[enum_sensor.options]]
+keys = [0, 1, 2, 3]
+values = ["off", "normal", "ECO", "COM"]
+
+# 4. krog
+[[enum_sensor]]
+register = 2070
+name = "Loop 4 regulation status"
+[[enum_sensor.options]]
+keys = [0, 1]
+values = ["constant temperature", "weather compensated"]
+
+[[enum_sensor]]
+register = 2074
+name = "Loop 4 operation status on schedule"
+[[enum_sensor.options]]
+keys = [0, 1, 2, 3]
+values = ["off", "normal", "ECO", "COM"]
+
+# Bazen
+[[enum_sensor_disabled]]
+register = 2083
+name = "Pool operation status on schedule"
+[[enum_sensor_disabled.options]]
+keys = [0, 1, 2, 3]
+values = ["off", "normal", "ECO", "comfort"]
+
+
+# ============================================================
+# Binary senzorji (Binary sensors)
+# ============================================================
+
+# Statusi
 [[binary_sensor]]
 register = 2000
 name = "System operation"
 device_class = ""
-
-[[binary_sensor]]
-register = 2045
-name = "Loop 1 circulation pump status"
-device_class = "running"
-
-[[binary_sensor]]
-register = 2055
-name = "Loop 2 circulation pump status"
-device_class = "running"
 
 [[binary_sensor]]
 register = 2002
@@ -295,6 +765,37 @@ device_class = "running"
 bit = 4
 
 [[binary_sensor]]
+register = 2003
+name = "Reserve source status"
+device_class = "running"
+
+[[binary_sensor]]
+register = 2004
+name = "Alternative source status"
+device_class = "running"
+
+[[binary_sensor]]
+register = 2005
+name = "Passive cooling status"
+device_class = "running"
+
+[[binary_sensor]]
+register = 2009
+name = "Service required"
+device_class = "problem"
+
+[[binary_sensor]]
+register = 2010
+name = "Forced DHW heating"
+device_class = "running"
+
+[[binary_sensor]]
+register = 2011
+name = "Defrosting"
+device_class = "running"
+
+# Sanitarna voda
+[[binary_sensor]]
 register = 2028
 name = "DHW circulation pump"
 device_class = "running"
@@ -306,9 +807,81 @@ name = "Circulation Pump for DHW tank"
 device_class = "running"
 bit = 1
 
+# Zalogovnik
+[[binary_sensor]]
+register = 2038
+name = "Main circulation pump"
+device_class = "running"
+
+[[binary_sensor]]
+register = 2039
+name = "Remote disconnect status"
+device_class = "power"
+
+# 1. krog
+[[binary_sensor]]
+register = 2045
+name = "Loop 1 circulation pump status"
+device_class = "running"
+
+[[binary_sensor]]
+register = 2046
+name = "Loop 1 thermostat status"
+device_class = ""
+bit = 0
+
+# 2. krog
+[[binary_sensor]]
+register = 2055
+name = "Loop 2 circulation pump status"
+device_class = "running"
+
+[[binary_sensor]]
+register = 2056
+name = "Loop 2 thermostat status"
+device_class = ""
+
+# 3. krog
+[[binary_sensor]]
+register = 2065
+name = "Loop 3 circulation pump status"
+device_class = "running"
+
+[[binary_sensor]]
+register = 2066
+name = "Loop 3 thermostat status"
+device_class = ""
+
+# 4. krog
+[[binary_sensor]]
+register = 2075
+name = "Loop 4 circulation pump status"
+device_class = "running"
+
+[[binary_sensor]]
+register = 2076
+name = "Loop 4 thermostat status"
+device_class = ""
+
+# Bazen
+[[binary_sensor_disabled]]
+register = 2084
+name = "Pool circulation pump"
+device_class = "running"
+
+[[binary_sensor_disabled]]
+register = 2085
+name = "Pool thermostat status"
+device_class = ""
+
+
+# ============================================================
+# Stikala (Switches)
+# ============================================================
+
 [[switch]]
-register = 2328
-name = "Circulation of sanitary water"
+register = 2012
+name = "System power"
 
 [[switch]]
 register = 2015
@@ -318,10 +891,95 @@ name = "Fast DHW heating"
 register = 2016
 name = "Additional Source"
 
+[[switch]]
+register = 2018
+name = "Reserve source"
+
+[[switch_disabled]]
+register = 2019
+name = "Defrosting"
+
+[[switch_disabled]]
+register = 2020
+name = "Pool heating"
+
+[[switch]]
+register = 2328
+name = "Circulation of sanitary water"
+
+
+# ============================================================
+# Izbirniki (Selects)
+# ============================================================
+
+[[select]]
+register = 2013
+name = "Operating program selection"
+default_option = "auto"
+[[select.options]]
+keys = [0, 1, 2]
+values = ["auto", "ECO", "comfort"]
+
+[[select]]
+register = 2017
+name = "Regime selection"
+default_option = "auto"
+[[select.options]]
+keys = [0, 1, 2]
+values = ["auto", "summer", "winter"]
+
 [[select]]
 register = 2026
 name = "Domestic Hot Water Operation"
 default_option = "On"
 [[select.options]]
+keys = [0, 1, 2]
+values = ["Off", "On", "Scheduled"]
+
+[[select]]
+register = 2035
+name = "Buffer operation"
+default_option = "On"
+[[select.options]]
+keys = [0, 1, 2]
+values = ["Off", "On", "Scheduled"]
+
+[[select]]
+register = 2042
+name = "Loop 1 operation"
+default_option = "On"
+[[select.options]]
+keys = [0, 1, 2]
+values = ["Off", "On", "Scheduled"]
+
+[[select]]
+register = 2052
+name = "Loop 2 operation"
+default_option = "On"
+[[select.options]]
+keys = [0, 1, 2]
+values = ["Off", "On", "Scheduled"]
+
+[[select]]
+register = 2062
+name = "Loop 3 operation"
+default_option = "On"
+[[select.options]]
+keys = [0, 1, 2]
+values = ["Off", "On", "Scheduled"]
+
+[[select]]
+register = 2072
+name = "Loop 4 operation"
+default_option = "On"
+[[select.options]]
+keys = [0, 1, 2]
+values = ["Off", "On", "Scheduled"]
+
+[[select_disabled]]
+register = 2081
+name = "Pool operation"
+default_option = "On"
+[[select_disabled.options]]
 keys = [0, 1, 2]
 values = ["Off", "On", "Scheduled"]

--- a/kronoterm2mqtt/examples/dashboard-overview.yaml
+++ b/kronoterm2mqtt/examples/dashboard-overview.yaml
@@ -96,6 +96,122 @@ views:
               - sensor.heat_pump_working_function
             show_names: false
             hours_to_show: 1
+      - type: vertical-stack
+        cards:
+          - type: custom:apexcharts-card
+            graph_span: 12h
+            apex_config:
+              legend:
+                show: true
+            header:
+              show: true
+              title: 1. krog
+              show_states: true
+              colorize_states: true
+            series:
+              - entity: sensor.heat_pump_loop_1_temperature
+                name: Temperatura
+                stroke_width: 1
+                color: red
+              - entity: sensor.heat_pump_loop_1_current_desired_temperature
+                name: Željena
+                stroke_width: 2
+                color: darkred
+          - type: entities
+            entities:
+              - entity: binary_sensor.heat_pump_loop_1_circulation_pump_status
+                name: Obtočna črpalka
+              - entity: sensor.heat_pump_loop_1_operation_status_on_schedule
+                name: Status po urniku
+              - entity: sensor.heat_pump_loop_1_thermostat_temperature
+                name: Termostat
+      - type: vertical-stack
+        cards:
+          - type: custom:apexcharts-card
+            graph_span: 12h
+            apex_config:
+              legend:
+                show: true
+            header:
+              show: true
+              title: 2. krog
+              show_states: true
+              colorize_states: true
+            series:
+              - entity: sensor.heat_pump_loop_2_temperature
+                name: Temperatura
+                stroke_width: 1
+                color: red
+              - entity: sensor.heat_pump_loop_2_current_desired_temperature
+                name: Željena
+                stroke_width: 2
+                color: darkred
+          - type: entities
+            entities:
+              - entity: binary_sensor.heat_pump_loop_2_circulation_pump_status
+                name: Obtočna črpalka
+              - entity: sensor.heat_pump_loop_2_operation_status_on_schedule
+                name: Status po urniku
+              - entity: sensor.heat_pump_loop_2_thermostat_temperature
+                name: Termostat
+      - type: vertical-stack
+        cards:
+          - type: custom:apexcharts-card
+            graph_span: 12h
+            apex_config:
+              legend:
+                show: true
+            header:
+              show: true
+              title: 3. krog
+              show_states: true
+              colorize_states: true
+            series:
+              - entity: sensor.heat_pump_loop_3_temperature
+                name: Temperatura
+                stroke_width: 1
+                color: red
+              - entity: sensor.heat_pump_loop_3_current_desired_temperature
+                name: Željena
+                stroke_width: 2
+                color: darkred
+          - type: entities
+            entities:
+              - entity: binary_sensor.heat_pump_loop_3_circulation_pump_status
+                name: Obtočna črpalka
+              - entity: sensor.heat_pump_loop_3_operation_status_on_schedule
+                name: Status po urniku
+              - entity: sensor.heat_pump_loop_3_thermostat_temperature
+                name: Termostat
+      - type: vertical-stack
+        cards:
+          - type: custom:apexcharts-card
+            graph_span: 12h
+            apex_config:
+              legend:
+                show: true
+            header:
+              show: true
+              title: 4. krog
+              show_states: true
+              colorize_states: true
+            series:
+              - entity: sensor.heat_pump_loop_4_temperature
+                name: Temperatura
+                stroke_width: 1
+                color: red
+              - entity: sensor.heat_pump_loop_4_current_desired_temperature
+                name: Željena
+                stroke_width: 2
+                color: darkred
+          - type: entities
+            entities:
+              - entity: binary_sensor.heat_pump_loop_4_circulation_pump_status
+                name: Obtočna črpalka
+              - entity: sensor.heat_pump_loop_4_operation_status_on_schedule
+                name: Status po urniku
+              - entity: sensor.heat_pump_loop_4_thermostat_temperature
+                name: Termostat
       - type: entities
         entities:
           - entity: sensor.heat_pump_operating_hours_compressor_heating
@@ -130,12 +246,6 @@ views:
                 name: Izstop
                 stroke_width: 1
                 color: lightblue
-              - entity: sensor.heat_pump_source_temperature_difference
-                name: Razlika
-                stroke_width: 1
-                color: green
-                show:
-                  in_chart: false
             graph_span: 1h
           - type: history-graph
             entities:

--- a/kronoterm2mqtt/examples/dashboard-overview.yaml
+++ b/kronoterm2mqtt/examples/dashboard-overview.yaml
@@ -109,11 +109,11 @@ views:
               show_states: true
               colorize_states: true
             series:
-              - entity: sensor.heat_pump_loop_1_temperature
+              - entity: sensor.heat_pump_loop_1_thermostat_temperature
                 name: Temperatura
                 stroke_width: 1
                 color: red
-              - entity: sensor.heat_pump_loop_1_current_desired_temperature
+              - entity: sensor.heat_pump_loop_1_current_desired_temperature_room
                 name: Željena
                 stroke_width: 2
                 color: darkred
@@ -138,11 +138,11 @@ views:
               show_states: true
               colorize_states: true
             series:
-              - entity: sensor.heat_pump_loop_2_temperature
+              - entity: sensor.heat_pump_loop_2_thermostat_temperature
                 name: Temperatura
                 stroke_width: 1
                 color: red
-              - entity: sensor.heat_pump_loop_2_current_desired_temperature
+              - entity: sensor.heat_pump_loop_2_current_desired_temperature_room
                 name: Željena
                 stroke_width: 2
                 color: darkred
@@ -167,11 +167,11 @@ views:
               show_states: true
               colorize_states: true
             series:
-              - entity: sensor.heat_pump_loop_3_temperature
+              - entity: sensor.heat_pump_loop_3_thermostat_temperature
                 name: Temperatura
                 stroke_width: 1
                 color: red
-              - entity: sensor.heat_pump_loop_3_current_desired_temperature
+              - entity: sensor.heat_pump_loop_3_current_desired_temperature_room
                 name: Željena
                 stroke_width: 2
                 color: darkred
@@ -196,11 +196,11 @@ views:
               show_states: true
               colorize_states: true
             series:
-              - entity: sensor.heat_pump_loop_4_temperature
+              - entity: sensor.heat_pump_loop_4_thermostat_temperature
                 name: Temperatura
                 stroke_width: 1
                 color: red
-              - entity: sensor.heat_pump_loop_4_current_desired_temperature
+              - entity: sensor.heat_pump_loop_4_current_desired_temperature_room
                 name: Željena
                 stroke_width: 2
                 color: darkred

--- a/kronoterm2mqtt/mqtt_connection.py
+++ b/kronoterm2mqtt/mqtt_connection.py
@@ -1,0 +1,96 @@
+import logging
+import ssl
+
+import paho.mqtt.client as mqtt
+from ha_services.mqtt4homeassistant.mqtt import get_connected_client as _upstream_get_connected_client
+
+from kronoterm2mqtt.user_settings import MqttTlsSettings, UserSettings
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_connected_client(user_settings: UserSettings, verbosity: int, timeout: int = 10) -> mqtt.Client:
+    """
+    Create and return a connected MQTT client with optional TLS support.
+
+    If TLS is not enabled, delegates to the upstream ha_services implementation.
+    If TLS is enabled, configures TLS before connecting.
+    """
+    tls_settings: MqttTlsSettings = user_settings.mqtt_tls
+    mqtt_settings = user_settings.mqtt
+
+    if not tls_settings.enabled:
+        return _upstream_get_connected_client(settings=mqtt_settings, verbosity=verbosity, timeout=timeout)
+
+    # TLS is enabled - we need to set up TLS before connect(),
+    # so we replicate the connection logic with TLS inserted.
+    from ha_services.mqtt4homeassistant.mqtt import OnConnectCallback, get_client_id
+
+    import socket
+
+    from bx_py_utils.anonymize import anonymize
+    from cli_base.cli_tools.rich_utils import human_error
+    from rich import print
+
+    client_id = get_client_id()
+    port = int(mqtt_settings.port)
+
+    if verbosity:
+        print(f'\nConnect [cyan]{mqtt_settings.host}:{port}[/cyan] as "[magenta]{client_id}[/magenta]"', end='...')
+
+    socket.setdefaulttimeout(timeout)
+    try:
+        info = socket.getaddrinfo(mqtt_settings.host, port)
+    except socket.gaierror as err:
+        human_error(
+            message=f'{err}\n(Hint: Check you host/port settings)',
+            title=f'[red]Error get address info from: [cyan]{mqtt_settings.host}:{port}[/cyan]',
+            exception=err,
+            exit_code=1,
+        )
+    else:
+        if not info:
+            print('[red]Resolve error: No info!')
+        elif verbosity:
+            print('Host/port test [green]OK')
+
+    mqttc = mqtt.Client(
+        mqtt.CallbackAPIVersion.VERSION2,
+        client_id=client_id,
+    )
+    mqttc.on_connect = OnConnectCallback(verbosity=verbosity)
+    mqttc.enable_logger(logger=logger)
+
+    if mqtt_settings.user_name and mqtt_settings.password:
+        if verbosity:
+            print(
+                f'login with user: {anonymize(mqtt_settings.user_name)} password:{anonymize(mqtt_settings.password)}',
+                end='...',
+            )
+        mqttc.username_pw_set(mqtt_settings.user_name, mqtt_settings.password)
+
+    # Configure TLS
+    ca_certs = tls_settings.ca_certs or None
+    certfile = tls_settings.certfile or None
+    keyfile = tls_settings.keyfile or None
+
+    if verbosity:
+        print(f'TLS enabled (ca_certs={ca_certs}, certfile={certfile})', end='...')
+
+    mqttc.tls_set(
+        ca_certs=ca_certs,
+        certfile=certfile,
+        keyfile=keyfile,
+        cert_reqs=ssl.CERT_REQUIRED,
+        tls_version=ssl.PROTOCOL_TLS_CLIENT,
+    )
+
+    if tls_settings.insecure:
+        mqttc.tls_insecure_set(True)
+
+    mqttc.connect(mqtt_settings.host, port=port)
+
+    if verbosity:
+        print('[green]OK')
+    return mqttc

--- a/kronoterm2mqtt/mqtt_handler.py
+++ b/kronoterm2mqtt/mqtt_handler.py
@@ -9,7 +9,7 @@ from ha_services.mqtt4homeassistant.components.select import Select
 from ha_services.mqtt4homeassistant.components.sensor import Sensor
 from ha_services.mqtt4homeassistant.components.switch import Switch
 from ha_services.mqtt4homeassistant.device import BaseMqttDevice, MqttDevice
-from ha_services.mqtt4homeassistant.mqtt import get_connected_client
+from kronoterm2mqtt.mqtt_connection import get_connected_client
 from ha_services.mqtt4homeassistant.utilities.string_utils import slugify
 from paho.mqtt.client import Client
 from pymodbus.exceptions import ModbusIOException
@@ -33,7 +33,7 @@ class KronotermMqttHandler:
         self.verbosity = verbosity
         self.heat_pump = self.user_settings.heat_pump
         self.device_name = self.heat_pump.device_name
-        self.mqtt_client = get_connected_client(settings=user_settings.mqtt, verbosity=verbosity)
+        self.mqtt_client = get_connected_client(user_settings=user_settings, verbosity=verbosity)
         self.mqtt_client.loop_start()
         self.modbus_client = None
         self.expander: Optional[ExpanderMqttHandler] = (

--- a/kronoterm2mqtt/user_settings.py
+++ b/kronoterm2mqtt/user_settings.py
@@ -22,6 +22,23 @@ logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
+class MqttTlsSettings:
+    """
+    TLS/SSL settings for MQTT connection.
+
+    Set 'enabled' to true to use TLS.
+    Provide 'ca_certs' path for server certificate verification.
+    Provide 'certfile' and 'keyfile' for mutual TLS (client certificate auth).
+    """
+
+    enabled: bool = False
+    ca_certs: str = ''  # Path to CA certificate file
+    certfile: str = ''  # Path to PEM-encoded client certificate
+    keyfile: str = ''  # Path to PEM-encoded client private key
+    insecure: bool = False  # If true, skip hostname verification
+
+
+@dataclasses.dataclass
 class HeatPump:
     """
     The "definitions_name" is the prefix of "kronoterm2mqtt/definitions/*.toml" files!
@@ -152,6 +169,9 @@ class UserSettings:
 
     # Information about the MQTT server:
     mqtt: dataclasses = dataclasses.field(default_factory=MqttSettings)
+
+    # TLS settings for MQTT connection:
+    mqtt_tls: dataclasses = dataclasses.field(default_factory=MqttTlsSettings)
 
     systemd: dataclasses = dataclasses.field(default_factory=SystemdServiceInfo)
 


### PR DESCRIPTION
- Add Dockerfile and docker-compose.yml for containerized deployment
- Add MQTT TLS/SSL support with optional mutual TLS (client certificates)
- New MqttTlsSettings dataclass with enabled, ca_certs, certfile, keyfile, and insecure options configurable via kronoterm2mqtt.toml
- Custom get_connected_client() wraps upstream ha_services to call tls_set() before connect() when TLS is enabled
- Add .dockerignore to keep image lean
- Update README with Docker usage instructions